### PR TITLE
add animated page transitions

### DIFF
--- a/src/lib/app/style.css
+++ b/src/lib/app/style.css
@@ -93,6 +93,7 @@ body {
 #root {
 	height: 100%;
 	position: relative;
+	overflow-y: scroll; /* prevents scrollbar weirdness with animated page transitions */
 }
 
 hr {

--- a/src/lib/app/style.css
+++ b/src/lib/app/style.css
@@ -88,12 +88,13 @@ body {
 	color: var(--text_color);
 	font-size: 18px;
 	line-height: 1.2;
+	/* prevents scrollbar weirdness with animated page transitions */
+	overflow-y: scroll;
 }
 
 #root {
 	height: 100%;
 	position: relative;
-	overflow-y: scroll; /* prevents scrollbar weirdness with animated page transitions */
 }
 
 hr {

--- a/src/routes/[...slug].svelte
+++ b/src/routes/[...slug].svelte
@@ -20,7 +20,10 @@
 	import voidPortal from '$lib/portals/void/data';
 	import VoidPortalView from '$lib/portals/void/View.svelte';
 
-	let swapped = false; // used to keep the outgoing view mounted in the DOM
+	// `swapped` is used to keep the outgoing view mounted in the DOM
+	// so it doesn't re-render to a new location.
+	// Maybe we want to use the Svelte builtin `crossfade` instead?
+	let swapped = false;
 
 	let view1: typeof SvelteComponent | undefined;
 	let view2: typeof SvelteComponent | undefined;

--- a/src/routes/[...slug].svelte
+++ b/src/routes/[...slug].svelte
@@ -12,7 +12,7 @@
 
 <script lang="ts">
 	import {type SvelteComponent} from 'svelte';
-	import {slide} from 'svelte/transition';
+	import {scale} from 'svelte/transition';
 
 	import {findPortalBySlug, getPortals} from '$lib/app/portalsStore';
 	import homePortal from '$lib/portals/home/data';
@@ -22,7 +22,7 @@
 
 	// `swapped` is used to keep the outgoing view mounted in the DOM
 	// so it doesn't re-render to a new location.
-	// Maybe we want to use the Svelte builtin `crossfade` instead?
+	// Maybe we want to use the Svelte builtin `crossscale` instead?
 	let swapped = false;
 
 	let view1: typeof SvelteComponent | undefined;
@@ -67,16 +67,20 @@
 
 <!-- TODO loading state? animate transitions between views? -->
 <!-- <div class="outer"> -->
-{#if view1 && !swapped}
-	<div class="inner" transition:slide>
-		<svelte:component this={view1} />
-	</div>
-{/if}
-{#if view2 && swapped}
-	<div class="inner" transition:slide>
-		<svelte:component this={view2} />
-	</div>
-{/if}
+<div class="outer" class:detached={swapped}>
+	{#if view1 && !swapped}
+		<div class="inner" transition:scale>
+			<svelte:component this={view1} />
+		</div>
+	{/if}
+</div>
+<div class="outer" class:detached={!swapped}>
+	{#if view2 && swapped}
+		<div class="inner" transition:scale>
+			<svelte:component this={view2} />
+		</div>
+	{/if}
+</div>
 
 <!-- </div> -->
 <style>
@@ -87,9 +91,22 @@
 		flex-direction: column;
 		align-items: center;
 	} */
-	/* .inner {
+	.inner {
+		/* position: absolute;
+		left: 0;
+		top: 0; */
+		width: 100%;
+	}
+	/* TODO instead of `detached` class maybe use `outrostart` to set `position: absolute` */
+	.outer {
+		width: 100%;
+		height: 100%; /* makes the scrollbar synchronously have the correct height so it can be restored */
+	}
+	.detached {
 		position: absolute;
 		left: 0;
 		top: 0;
-	} */
+		overflow: hidden;
+		z-index: -1; /* needed because we're currently still rendering `.outer` elements when empty */
+	}
 </style>

--- a/src/routes/[...slug].svelte
+++ b/src/routes/[...slug].svelte
@@ -22,7 +22,7 @@
 
 	// `swapped` is used to keep the outgoing view mounted in the DOM
 	// so it doesn't re-render to a new location.
-	// Maybe we want to use the Svelte builtin `crossscale` instead?
+	// Maybe we want to use the Svelte builtin `crossfade` instead?
 	let swapped = false;
 
 	let view1: typeof SvelteComponent | undefined;
@@ -66,7 +66,6 @@
 </script>
 
 <!-- TODO loading state? animate transitions between views? -->
-<!-- <div class="outer"> -->
 <div class="outer" class:detached={swapped}>
 	{#if view1 && !swapped}
 		<div class="inner" transition:scale>
@@ -82,19 +81,8 @@
 	{/if}
 </div>
 
-<!-- </div> -->
 <style>
-	/* .outer {
-		position: relative;
-		width: 100%;
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-	} */
 	.inner {
-		/* position: absolute;
-		left: 0;
-		top: 0; */
 		width: 100%;
 	}
 	/* TODO instead of `detached` class maybe use `outrostart` to set `position: absolute` */

--- a/src/routes/[...slug].svelte
+++ b/src/routes/[...slug].svelte
@@ -12,7 +12,7 @@
 
 <script lang="ts">
 	import {type SvelteComponent} from 'svelte';
-	import {scale} from 'svelte/transition';
+	import {slide} from 'svelte/transition';
 
 	import {findPortalBySlug, getPortals} from '$lib/app/portalsStore';
 	import homePortal from '$lib/portals/home/data';
@@ -20,7 +20,7 @@
 	import voidPortal from '$lib/portals/void/data';
 	import VoidPortalView from '$lib/portals/void/View.svelte';
 
-	let swapped = false;
+	let swapped = false; // used to keep the outgoing view mounted in the DOM
 
 	let view1: typeof SvelteComponent | undefined;
 	let view2: typeof SvelteComponent | undefined;
@@ -63,21 +63,30 @@
 </script>
 
 <!-- TODO loading state? animate transitions between views? -->
+<!-- <div class="outer"> -->
 {#if view1 && !swapped}
-	<div class="inner" transition:scale>
+	<div class="inner" transition:slide>
 		<svelte:component this={view1} />
 	</div>
 {/if}
 {#if view2 && swapped}
-	<div class="inner" transition:scale>
+	<div class="inner" transition:slide>
 		<svelte:component this={view2} />
 	</div>
 {/if}
 
+<!-- </div> -->
 <style>
-	.inner {
+	/* .outer {
+		position: relative;
+		width: 100%;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+	} */
+	/* .inner {
 		position: absolute;
 		left: 0;
 		top: 0;
-	}
+	} */
 </style>


### PR DESCRIPTION
**update**: I changed the structure from the generic route seen in this PR to proper SvelteKit routes in in #10 -- I'll probably pick up this feature again in a new PR but more directly take inspiration from the projected linked below

This is an experiment (currently **very hacky** but demonstrates the concept) that changes navigation to visually transition to the incoming portal page, inspired by [pngwn/svelte-travel-transitions](https://github.com/pngwn/svelte-travel-transitions) but not yet implemented in a generic way for all routes (all current routes in this app yes, but we could do better). It's enabled by #7 and has some currently broken things and some caveats that may be blocking. It's possible the strategy I'm currently taking is hopelessly broken, but perhaps there's an actually good implementation we can land on.

- [ ] is the scroll fix any good? 
- [ ] fix scrollbars showing for portals that should be 100% width/height with no overflow (caused by setting width/height in the portals from dimensions)
- [ ] fix layout for other kinds of transitions (`scale` happens to mostly hide the problem)
- [ ] did we break anything else?
- [ ] animate something while loading the incoming portal
- [ ] what's the best visual transition? (in keeping with the theme, maybe zooming into and out of portals)