### PR TITLE
tweaks after pinch-to-zoom

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,9 +31,6 @@ It's made with Svelte, SvelteKit, Vite, TypeScript, PixiJS, and _space_.
   Try it on an idle screen but be mindful of the power usage. :]
   - Safari users: Starlit Hammock uses the modern image format webp instead of jpg,
     which means it only works on iOS 14 & macOS Big Sur or later
-- mobile caveats D:
-  - pinch-to-zoom doesn't work yet (I'm being stubborn and don't want to use a library)
-  - some mobile browsers may crash if the GPU can't handle the load :|
 - Two tools for understanding
   [the easing functions in Svelte](https://svelte.dev/docs#run-time-svelte-easing)
   (see also [the official example](https://svelte.dev/examples/easing)):

--- a/src/lib/app/Surface.svelte
+++ b/src/lib/app/Surface.svelte
@@ -15,6 +15,20 @@
 	export let moveCamera: (dx: number, dy: number) => void;
 	export let inputEnabled = true;
 
+	let debugArgs: any[] = [];
+
+	const debugZoomCamera: (
+		zoomDirection: number,
+		screenPivotX: number,
+		screenPivotY: number,
+		multipler?: number,
+	) => void = (...args) => {
+		zoomCamera(...args);
+		const nextDebugArgs = debugArgs.slice(-20);
+		nextDebugArgs.push(args);
+		debugArgs = nextDebugArgs;
+	};
+
 	// TODO probably refactor these, written before `events` was added for pinch gestures
 	let pointerDown = false;
 	let pointerX: number | null = null;
@@ -48,7 +62,7 @@
 	const wheel = (e: WheelEvent) => {
 		const {x, y} = toPointerPosition(e.clientX, e.clientY, el);
 		const scaleDelta = e.deltaX + e.deltaY + e.deltaZ;
-		zoomCamera(scaleDelta, x, y); // TODO handle sensitivity
+		debugZoomCamera(scaleDelta, x, y); // TODO handle sensitivity
 	};
 
 	const pointerdown = (e: PointerEvent) => {
@@ -95,7 +109,7 @@
 				const delta = last_pinch_distance - distance;
 				const magnitude = Math.abs(delta / 0.33); // magic number for per-event deltas
 				const sensitivity = magnitude * (POINTER_ZOOM_SENSITIVITY - 1) + 1; // TODO super hacky
-				zoomCamera(delta, (x1 + x2) / 2, (y1 + y2) / 2, sensitivity); // TODO is weird that `delta` is only for direction, see the API, merge with `sensitivity` probably
+				debugZoomCamera(delta, (x1 + x2) / 2, (y1 + y2) / 2, sensitivity); // TODO is weird that `delta` is only for direction, see the API, merge with `sensitivity` probably
 			}
 			last_pinch_distance = distance;
 		}
@@ -121,6 +135,11 @@
 	on:touchmove|nonpassive={swallow}
 >
 	<slot />
+	<div class="debugging">
+		{#each debugArgs as a}
+			<div>{a[0]} - {a[1]} - {a[2]} - {a[3] ?? ''}</div>
+		{/each}
+	</div>
 </div>
 
 <style>
@@ -128,5 +147,14 @@
 		-webkit-user-select: none;
 		user-select: none;
 		touch-action: none;
+	}
+	.debugging {
+		position: fixed;
+		left: 0;
+		top: 0;
+		height: 100%;
+		width: 100px;
+		user-select: none;
+		font-size: var(--font_size_sm);
 	}
 </style>

--- a/src/lib/app/Surface.svelte
+++ b/src/lib/app/Surface.svelte
@@ -22,6 +22,7 @@
 		x2: number;
 		y1: number;
 		y2: number;
+		pointerId: number;
 	}> = [];
 
 	const debugZoomCamera: (
@@ -29,6 +30,7 @@
 		screenPivotX: number,
 		screenPivotY: number,
 		multiplier?: number,
+		pointerId: number,
 	) => void = (zoomDirection, screenPivotX, screenPivotY, multiplier) => {
 		zoomCamera(zoomDirection, screenPivotX, screenPivotY, multiplier);
 		const nextDebugArgs = debugArgs.slice(-20);
@@ -37,7 +39,7 @@
 		const y1 = es[0]?.clientY;
 		const x2 = es[1]?.clientX;
 		const y2 = es[1]?.clientY;
-		nextDebugArgs.push({zoomDirection, multiplier, x1, x2, y1, y2});
+		nextDebugArgs.push({zoomDirection, multiplier, x1, x2, y1, y2, pointerId});
 		debugArgs = nextDebugArgs;
 	};
 
@@ -121,7 +123,7 @@
 				const delta = last_pinch_distance - distance;
 				const magnitude = Math.abs(delta / 0.33); // magic number for per-event deltas
 				const sensitivity = magnitude * (POINTER_ZOOM_SENSITIVITY - 1) + 1; // TODO super hacky
-				debugZoomCamera(delta, (x1 + x2) / 2, (y1 + y2) / 2, sensitivity); // TODO is weird that `delta` is only for direction, see the API, merge with `sensitivity` probably
+				debugZoomCamera(delta, (x1 + x2) / 2, (y1 + y2) / 2, sensitivity, e.pointerId); // TODO is weird that `delta` is only for direction, see the API, merge with `sensitivity` probably
 			}
 			last_pinch_distance = distance;
 		}
@@ -152,6 +154,7 @@
 					<td>{a.multiplier?.toFixed(3) ?? ''}</td>
 					<td>{a.x1}, {a.y1}</td>
 					<td>{a.x2}, {a.y2}</td>
+					<td>{a.pointerId}</td>
 				</tr>
 			{/each}
 		</table>

--- a/src/lib/app/Surface.svelte
+++ b/src/lib/app/Surface.svelte
@@ -123,7 +123,7 @@
 				const delta = last_pinch_distance - distance;
 				const magnitude = Math.abs(delta / 0.33); // magic number for per-event deltas
 				const sensitivity = magnitude * (POINTER_ZOOM_SENSITIVITY - 1) + 1; // TODO super hacky
-				debugZoomCamera(delta, (x1 + x2) / 2, (y1 + y2) / 2, e.pointerId, sensitivity); // TODO is weird that `delta` is only for direction, see the API, merge with `sensitivity` probably
+				debugZoomCamera(delta, (x1 + x2) / 2, (y1 + y2) / 2, magnitude, sensitivity); // TODO is weird that `delta` is only for direction, see the API, merge with `sensitivity` probably
 			}
 			last_pinch_distance = distance;
 		}

--- a/src/lib/app/Surface.svelte
+++ b/src/lib/app/Surface.svelte
@@ -22,7 +22,9 @@
 		x2: number;
 		y1: number;
 		y2: number;
+		dt: number;
 	}> = [];
+	let last_t: number | null = null;
 
 	const debugZoomCamera: (
 		zoomDirection: number,
@@ -37,7 +39,10 @@
 		const y1 = es[0]?.clientY;
 		const x2 = es[1]?.clientX;
 		const y2 = es[1]?.clientY;
-		nextDebugArgs.push({zoomDirection, multiplier, x1, x2, y1, y2});
+		const t = performance.now();
+		const dt = last_t === null ? 0 : Math.round(t - last_t);
+		last_t = t;
+		nextDebugArgs.push({zoomDirection, multiplier, x1, x2, y1, y2, dt});
 		debugArgs = nextDebugArgs;
 	};
 
@@ -128,8 +133,6 @@
 	};
 </script>
 
-<!-- on:mouseenter={onMouseEnter} -->
-
 <div
 	bind:this={el}
 	class="surface"
@@ -142,9 +145,8 @@
 	on:pointerleave={inputEnabled ? pointerup : undefined}
 	on:pointercancel={inputEnabled ? pointerup : undefined}
 	on:pointerout={inputEnabled ? pointerup : undefined}
-	on:touchstart|nonpassive={swallow}
-	on:touchend|nonpassive={swallow}
-	on:touchmove|nonpassive={swallow}
+	on:touchstart|nonpassive={inputEnabled ? swallow : undefined}
+	on:touchmove|nonpassive={inputEnabled ? swallow : undefined}
 >
 	<slot />
 	<div class="debugging">
@@ -155,6 +157,7 @@
 					<td>{a.multiplier?.toFixed(3) ?? ''}</td>
 					<td>{a.x1}, {a.y1}</td>
 					<td>{a.x2}, {a.y2}</td>
+					<td>{a.dt}</td>
 				</tr>
 			{/each}
 		</table>

--- a/src/lib/app/Surface.svelte
+++ b/src/lib/app/Surface.svelte
@@ -10,27 +10,34 @@
 		zoomDirection: number,
 		screenPivotX: number,
 		screenPivotY: number,
-		multipler?: number,
+		multiplier?: number,
 	) => void;
 	export let moveCamera: (dx: number, dy: number) => void;
 	export let inputEnabled = true;
 
-	let debugArgs: any[] = [];
+	let debugArgs: Array<{
+		zoomDirection: number;
+		multiplier?: number;
+		x1: number;
+		x2: number;
+		y1: number;
+		y2: number;
+	}> = [];
 
 	const debugZoomCamera: (
 		zoomDirection: number,
 		screenPivotX: number,
 		screenPivotY: number,
-		multipler?: number,
-	) => void = (zoomDirection, screenPivotX, screenPivotY, multipler) => {
-		zoomCamera(zoomDirection, screenPivotX, screenPivotY, multipler);
+		multiplier?: number,
+	) => void = (zoomDirection, screenPivotX, screenPivotY, multiplier) => {
+		zoomCamera(zoomDirection, screenPivotX, screenPivotY, multiplier);
 		const nextDebugArgs = debugArgs.slice(-20);
 		const es = Array.from(events.values());
 		const x1 = es[0]?.clientX;
 		const y1 = es[0]?.clientY;
 		const x2 = es[1]?.clientX;
 		const y2 = es[1]?.clientY;
-		nextDebugArgs.push({zoomDirection, multipler, x1, x2, y1, y2});
+		nextDebugArgs.push({zoomDirection, multiplier, x1, x2, y1, y2});
 		debugArgs = nextDebugArgs;
 	};
 
@@ -140,13 +147,18 @@
 	on:touchmove|nonpassive={swallow}
 >
 	<slot />
-	<table class="debugging">
-		{#each debugArgs as a}
-			<tr>
-				<td>{a[0].toFixed(1)}</td><td>{a[1]}</td><td>{a[2]}</td><td>{a[3]?.toFixed(3) ?? ''}</td>
-			</tr>
-		{/each}
-	</table>
+	<div class="debugging">
+		<table>
+			{#each debugArgs as a}
+				<tr>
+					<td>{a.zoomDirection.toFixed(1)}</td>
+					<td>{a.multiplier?.toFixed(3) ?? ''}</td>
+					<td>{a.x1}, {a.y1}</td>
+					<td>{a.x2}, {a.y2}</td>
+				</tr>
+			{/each}
+		</table>
+	</div>
 </div>
 
 <style>
@@ -163,5 +175,11 @@
 		user-select: none;
 		font-size: var(--font_size_sm);
 		white-space: nowrap;
+	}
+	tr {
+		height: 20px;
+	}
+	td {
+		padding: 0 var(--spacing_xs);
 	}
 </style>

--- a/src/lib/app/Surface.svelte
+++ b/src/lib/app/Surface.svelte
@@ -137,7 +137,7 @@
 	<slot />
 	<div class="debugging">
 		{#each debugArgs as a}
-			<div>{a[0]} - {a[1]} - {a[2]} - {a[3] ?? ''}</div>
+			<div>{a[0]} - {a[1]} - {a[2]} - {a[3]?.toString().slice(0, 6) ?? ''}</div>
 		{/each}
 	</div>
 </div>

--- a/src/lib/app/Surface.svelte
+++ b/src/lib/app/Surface.svelte
@@ -107,7 +107,8 @@
 <div
 	bind:this={el}
 	class="surface"
-	style="width: {width}px; height: {height}px;"
+	style:width="{width}px"
+	style:height="{height}px"
 	on:wheel|passive={inputEnabled ? wheel : undefined}
 	on:pointerdown={inputEnabled ? pointerdown : undefined}
 	on:pointermove={inputEnabled ? pointermove : undefined}
@@ -115,6 +116,9 @@
 	on:pointerleave={inputEnabled ? pointerup : undefined}
 	on:pointercancel={inputEnabled ? pointerup : undefined}
 	on:pointerout={inputEnabled ? pointerup : undefined}
+	on:touchstart|nonpassive={swallow}
+	on:touchend|nonpassive={swallow}
+	on:touchmove|nonpassive={swallow}
 >
 	<slot />
 </div>

--- a/src/lib/app/Surface.svelte
+++ b/src/lib/app/Surface.svelte
@@ -76,7 +76,6 @@
 	};
 	const pointermove = (e: PointerEvent) => {
 		swallow(e);
-		if (!events.has(e.pointerId)) throw Error(); // TODO delete this line
 		events.set(e.pointerId, e);
 		// when 2 pointers are down, handle pinch-to-zoom gestures
 		const eventCount = events.size;

--- a/src/lib/app/Surface.svelte
+++ b/src/lib/app/Surface.svelte
@@ -177,7 +177,7 @@
 		white-space: nowrap;
 	}
 	tr {
-		height: 20px;
+		height: 17px;
 	}
 	td {
 		padding: 0 var(--spacing_xs);

--- a/src/lib/app/Surface.svelte
+++ b/src/lib/app/Surface.svelte
@@ -22,10 +22,15 @@
 		screenPivotX: number,
 		screenPivotY: number,
 		multipler?: number,
-	) => void = (...args) => {
-		zoomCamera(...args);
+	) => void = (zoomDirection, screenPivotX, screenPivotY, multipler) => {
+		zoomCamera(zoomDirection, screenPivotX, screenPivotY, multipler);
 		const nextDebugArgs = debugArgs.slice(-20);
-		nextDebugArgs.push(args);
+		const es = Array.from(events.values());
+		const x1 = es[0]?.clientX;
+		const y1 = es[0]?.clientY;
+		const x2 = es[1]?.clientX;
+		const y2 = es[1]?.clientY;
+		nextDebugArgs.push({zoomDirection, multipler, x1, x2, y1, y2});
 		debugArgs = nextDebugArgs;
 	};
 
@@ -135,13 +140,13 @@
 	on:touchmove|nonpassive={swallow}
 >
 	<slot />
-	<div class="debugging">
+	<table class="debugging">
 		{#each debugArgs as a}
-			<div>
-				{a[0].toFixed(1)} - {a[1]} - {a[2]} - {a[3]?.toFixed(3) ?? ''}
-			</div>
+			<tr>
+				<td>{a[0].toFixed(1)}</td><td>{a[1]}</td><td>{a[2]}</td><td>{a[3]?.toFixed(3) ?? ''}</td>
+			</tr>
 		{/each}
-	</div>
+	</table>
 </div>
 
 <style>

--- a/src/lib/app/Surface.svelte
+++ b/src/lib/app/Surface.svelte
@@ -22,9 +22,7 @@
 		x2: number;
 		y1: number;
 		y2: number;
-		dt: number;
 	}> = [];
-	let last_t: number | null = null;
 
 	const debugZoomCamera: (
 		zoomDirection: number,
@@ -39,10 +37,7 @@
 		const y1 = es[0]?.clientY;
 		const x2 = es[1]?.clientX;
 		const y2 = es[1]?.clientY;
-		const t = performance.now();
-		const dt = last_t === null ? 0 : Math.round(t - last_t);
-		last_t = t;
-		nextDebugArgs.push({zoomDirection, multiplier, x1, x2, y1, y2, dt});
+		nextDebugArgs.push({zoomDirection, multiplier, x1, x2, y1, y2});
 		debugArgs = nextDebugArgs;
 	};
 
@@ -107,7 +102,7 @@
 	};
 	const pointermove = (e: PointerEvent) => {
 		swallow(e);
-		if (!events.has(e.pointerId)) return;
+		if (!events.has(e.pointerId)) throw Error(); // TODO delete this line
 		events.set(e.pointerId, e);
 		// when 2 pointers are down, handle pinch-to-zoom gestures
 		const eventCount = events.size;
@@ -157,7 +152,6 @@
 					<td>{a.multiplier?.toFixed(3) ?? ''}</td>
 					<td>{a.x1}, {a.y1}</td>
 					<td>{a.x2}, {a.y2}</td>
-					<td>{a.dt}</td>
 				</tr>
 			{/each}
 		</table>

--- a/src/lib/app/Surface.svelte
+++ b/src/lib/app/Surface.svelte
@@ -101,6 +101,9 @@
 	};
 </script>
 
+<!-- might want to try this if there are problems on iOS:
+	on:touchstart|nonpassive={inputEnabled ? swallow : undefined}
+	on:touchmove|nonpassive={inputEnabled ? swallow : undefined} -->
 <div
 	bind:this={el}
 	class="surface"
@@ -113,8 +116,6 @@
 	on:pointerleave={inputEnabled ? pointerup : undefined}
 	on:pointercancel={inputEnabled ? pointerup : undefined}
 	on:pointerout={inputEnabled ? pointerup : undefined}
-	on:touchstart|nonpassive={inputEnabled ? swallow : undefined}
-	on:touchmove|nonpassive={inputEnabled ? swallow : undefined}
 >
 	<slot />
 </div>

--- a/src/lib/app/Surface.svelte
+++ b/src/lib/app/Surface.svelte
@@ -29,9 +29,9 @@
 		zoomDirection: number,
 		screenPivotX: number,
 		screenPivotY: number,
-		multiplier?: number,
 		pointerId: number,
-	) => void = (zoomDirection, screenPivotX, screenPivotY, multiplier) => {
+		multiplier?: number,
+	) => void = (zoomDirection, screenPivotX, screenPivotY, pointerId, multiplier) => {
 		zoomCamera(zoomDirection, screenPivotX, screenPivotY, multiplier);
 		const nextDebugArgs = debugArgs.slice(-20);
 		const es = Array.from(events.values());
@@ -76,7 +76,7 @@
 	const wheel = (e: WheelEvent) => {
 		const {x, y} = toPointerPosition(e.clientX, e.clientY, el);
 		const scaleDelta = e.deltaX + e.deltaY + e.deltaZ;
-		debugZoomCamera(scaleDelta, x, y); // TODO handle sensitivity
+		debugZoomCamera(scaleDelta, x, y, 0); // TODO handle sensitivity
 	};
 
 	const pointerdown = (e: PointerEvent) => {
@@ -123,7 +123,7 @@
 				const delta = last_pinch_distance - distance;
 				const magnitude = Math.abs(delta / 0.33); // magic number for per-event deltas
 				const sensitivity = magnitude * (POINTER_ZOOM_SENSITIVITY - 1) + 1; // TODO super hacky
-				debugZoomCamera(delta, (x1 + x2) / 2, (y1 + y2) / 2, sensitivity, e.pointerId); // TODO is weird that `delta` is only for direction, see the API, merge with `sensitivity` probably
+				debugZoomCamera(delta, (x1 + x2) / 2, (y1 + y2) / 2, e.pointerId, sensitivity); // TODO is weird that `delta` is only for direction, see the API, merge with `sensitivity` probably
 			}
 			last_pinch_distance = distance;
 		}

--- a/src/lib/app/Surface.svelte
+++ b/src/lib/app/Surface.svelte
@@ -22,16 +22,16 @@
 		x2: number;
 		y1: number;
 		y2: number;
-		pointerId: number;
+		magnitude: number;
 	}> = [];
 
 	const debugZoomCamera: (
 		zoomDirection: number,
 		screenPivotX: number,
 		screenPivotY: number,
-		pointerId: number,
+		magnitude: number,
 		multiplier?: number,
-	) => void = (zoomDirection, screenPivotX, screenPivotY, pointerId, multiplier) => {
+	) => void = (zoomDirection, screenPivotX, screenPivotY, magnitude, multiplier) => {
 		zoomCamera(zoomDirection, screenPivotX, screenPivotY, multiplier);
 		const nextDebugArgs = debugArgs.slice(-20);
 		const es = Array.from(events.values());
@@ -39,7 +39,7 @@
 		const y1 = es[0]?.clientY;
 		const x2 = es[1]?.clientX;
 		const y2 = es[1]?.clientY;
-		nextDebugArgs.push({zoomDirection, multiplier, x1, x2, y1, y2, pointerId});
+		nextDebugArgs.push({zoomDirection, multiplier, x1, x2, y1, y2, magnitude});
 		debugArgs = nextDebugArgs;
 	};
 
@@ -154,7 +154,7 @@
 					<td>{a.multiplier?.toFixed(3) ?? ''}</td>
 					<td>{a.x1}, {a.y1}</td>
 					<td>{a.x2}, {a.y2}</td>
-					<td>{a.pointerId}</td>
+					<td>{a.magnitude}</td>
 				</tr>
 			{/each}
 		</table>

--- a/src/lib/app/Surface.svelte
+++ b/src/lib/app/Surface.svelte
@@ -120,10 +120,11 @@
 			const y2 = es[1].clientY;
 			const distance = Math.hypot(x2 - x1, y2 - y1);
 			if (last_pinch_distance !== null) {
+				const count = e.getCoalescedEvents().length;
 				const delta = last_pinch_distance - distance;
 				const magnitude = Math.abs(delta / 0.33); // magic number for per-event deltas
 				const sensitivity = magnitude * (POINTER_ZOOM_SENSITIVITY - 1) + 1; // TODO super hacky
-				debugZoomCamera(delta, (x1 + x2) / 2, (y1 + y2) / 2, magnitude, sensitivity); // TODO is weird that `delta` is only for direction, see the API, merge with `sensitivity` probably
+				debugZoomCamera(delta, (x1 + x2) / 2, (y1 + y2) / 2, count, sensitivity); // TODO is weird that `delta` is only for direction, see the API, merge with `sensitivity` probably
 			}
 			last_pinch_distance = distance;
 		}

--- a/src/lib/app/Surface.svelte
+++ b/src/lib/app/Surface.svelte
@@ -155,8 +155,8 @@
 		left: 0;
 		top: 0;
 		height: 100%;
-		width: 100px;
 		user-select: none;
 		font-size: var(--font_size_sm);
+		white-space: nowrap;
 	}
 </style>

--- a/src/lib/app/Surface.svelte
+++ b/src/lib/app/Surface.svelte
@@ -137,7 +137,9 @@
 	<slot />
 	<div class="debugging">
 		{#each debugArgs as a}
-			<div>{a[0].slice(0, 4)} - {a[1]} - {a[2]} - {a[3]?.toString().slice(0, 6) ?? ''}</div>
+			<div>
+				{a[0].toString().slice(0, 4)} - {a[1]} - {a[2]} - {a[3]?.toString().slice(0, 6) ?? ''}
+			</div>
 		{/each}
 	</div>
 </div>

--- a/src/lib/app/Surface.svelte
+++ b/src/lib/app/Surface.svelte
@@ -137,7 +137,7 @@
 	<slot />
 	<div class="debugging">
 		{#each debugArgs as a}
-			<div>{a[0]} - {a[1]} - {a[2]} - {a[3]?.toString().slice(0, 6) ?? ''}</div>
+			<div>{a[0].slice(0, 4)} - {a[1]} - {a[2]} - {a[3]?.toString().slice(0, 6) ?? ''}</div>
 		{/each}
 	</div>
 </div>

--- a/src/lib/app/Surface.svelte
+++ b/src/lib/app/Surface.svelte
@@ -138,7 +138,7 @@
 	<div class="debugging">
 		{#each debugArgs as a}
 			<div>
-				{a[0].toString().slice(0, 4)} - {a[1]} - {a[2]} - {a[3]?.toString().slice(0, 6) ?? ''}
+				{a[0].toFixed(1)} - {a[1]} - {a[2]} - {a[3]?.toFixed(3) ?? ''}
 			</div>
 		{/each}
 	</div>

--- a/src/routes/deep-breath/DeepBreathTitleScreen.svelte
+++ b/src/routes/deep-breath/DeepBreathTitleScreen.svelte
@@ -60,9 +60,10 @@
 				are below.
 			</p>
 			<p>
-				This page is not mobile friendly! Sorry... It may also be slow depending on your hardware
-				and browser. See <a href="https://www.youtube.com/watch?v=7xEPqg-Kyg4">the video</a> if it doesn't
-				work.
+				This map is resource-intensive and may be broken or slow depending on your hardware and
+				browser. More optimizations like <a
+					href="https://github.com/ryanatkn/cosmicplayground/issues/56">this one</a
+				> would help.
 			</p>
 			<p>See also <PortalLink slug="soggy-planet" />.</p>
 		</section>

--- a/src/routes/soggy-planet/Soggy_Planet_Title_Screen.svelte
+++ b/src/routes/soggy-planet/Soggy_Planet_Title_Screen.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import PendingAnimation from '@feltjs/felt-ui/PendingAnimation.svelte';
+
 	import Soggy_Planet_Thumbnail from '$routes/soggy-planet/Soggy_Planet_Thumbnail.svelte';
 	import Hud from '$lib/app/Hud.svelte';
 	import HomeButton from '$lib/app/HomeButton.svelte';
@@ -12,7 +14,6 @@
 	import type {ResourcesStore} from '$lib/app/resources';
 	import PortalLink from '$lib/app/PortalLink.svelte';
 	import {points_of_interest} from '$routes/soggy-planet/soggy_planet_tour_data';
-	import PendingAnimation from '@feltjs/felt-ui/PendingAnimation.svelte';
 
 	export let resources: ResourcesStore;
 	export let proceed: () => void;
@@ -86,10 +87,10 @@
 				<li>or learn more below</li>
 			</ul>
 			<p>
-				This page is not mobile friendly! Sorry... It may also be slow depending on your hardware
-				and browser. See <a href="https://github.com/ryanatkn/cosmicplayground/issues/56"
-					>this performance issue on GitHub</a
-				>.
+				This map is resource-intensive and may be broken or slow depending on your hardware and
+				browser. More optimizations like <a
+					href="https://github.com/ryanatkn/cosmicplayground/issues/56">this one</a
+				> would help.
 			</p>
 			<p>
 				The code and image data are

--- a/src/routes/soggy-planet/Soggy_Planet_Title_Screen.svelte
+++ b/src/routes/soggy-planet/Soggy_Planet_Title_Screen.svelte
@@ -12,6 +12,7 @@
 	import type {ResourcesStore} from '$lib/app/resources';
 	import PortalLink from '$lib/app/PortalLink.svelte';
 	import {points_of_interest} from '$routes/soggy-planet/soggy_planet_tour_data';
+	import PendingAnimation from '@feltjs/felt-ui/PendingAnimation.svelte';
 
 	export let resources: ResourcesStore;
 	export let proceed: () => void;
@@ -25,8 +26,11 @@
 	const has_loaded = !!localStorage.getItem(HAS_LOADED_KEY);
 	$: enable_loading_by_clicking_thumbnail = has_loaded;
 
+	let loading = false;
 	const load = async () => {
+		loading = true;
 		await resources.load();
+		loading = false;
 		if ($resources.status === 'success') {
 			if (!has_loaded) localStorage.setItem(HAS_LOADED_KEY, 'true');
 			proceed();
@@ -39,6 +43,11 @@
 </Hud>
 <div class="soggy-planet-title-screen">
 	<Soggy_Planet_Thumbnail onClick={enable_loading_by_clicking_thumbnail ? load : null} />
+	<div class="loading_animation">
+		{#if loading}
+			<PendingAnimation />
+		{/if}
+	</div>
 	<Panel>
 		<section class="markup">
 			<p>
@@ -152,5 +161,12 @@
 	/* TODO hacky */
 	.soggy-planet-title-screen :global(.portal-preview) {
 		margin: 0;
+	}
+
+	.loading_animation {
+		height: 0;
+		position: relative;
+		top: 48px;
+		color: var(--ocean_color);
 	}
 </style>


### PR DESCRIPTION
continues the work from work from #76 and #77 and #78 

oof this has been difficult - pinch-to-zoom is janky on my phone in Firefox for Android but not Chrome. After investigating it appears FF is delaying the firing of one of the pointer events, so it pops in a huge value after a quick gesture. I don't want to apply any heuristics to tamp down those events because Chrome seems to work flawlessly, and any tweaks would harm its behavior. So I think I need to take this one to Bugzilla.

also:

- add a loading indicator to the top of the soggy planet page
- update the "not mobile friendly" text